### PR TITLE
linting fixes

### DIFF
--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -12,6 +12,8 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 */
 
+/* eslint camelcase: "off" */
+
 import fetch from "isomorphic-fetch";
 import Cookie from "js-cookie";
 import { getActiveTimetable, getCurrentSemester, getDenormTimetable } from "../state";
@@ -396,7 +398,7 @@ export const updateCourses = (courses) => (dispatch, getState) => {
 
   // Prepare updated courses for adding
   const updatedCourses = courses.map(({ course_id, meeting_section }) => ({
-    course_id: course_id,
+    course_id,
     section_codes: [meeting_section], // Ensure this structure matches backend expectations
   }));
 

--- a/static/js/redux/state/slices/alertsSlice.ts
+++ b/static/js/redux/state/slices/alertsSlice.ts
@@ -2,6 +2,8 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { alertConflict, alertTimeTableExists } from "../../actions/initActions";
 import { Timetable } from "../../constants/commonTypes";
 
+/* eslint no-shadow: "off" */
+
 export enum AlertCoursePlanType {
   EMPTY = 0,
   EXCEEDS_LIMIT = 1,

--- a/static/js/redux/ui/SideBar.tsx
+++ b/static/js/redux/ui/SideBar.tsx
@@ -19,8 +19,7 @@ import ClickOutHandler from "react-onclickout";
 import MasterSlot from "./MasterSlot";
 import TimetableNameInput from "./TimetableNameInput";
 import CreditTicker from "./CreditTicker";
-import { alertsActions } from "../state/slices";
-import { AlertCoursePlanType } from "../state/slices";
+import { alertsActions , AlertCoursePlanType } from "../state/slices";
 import { getNextAvailableColour } from "../util";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import {
@@ -112,7 +111,11 @@ const SideBar = () => {
   const theme = useAppSelector(selectTheme);
   const isDarkMode = theme && theme.name && theme.name === "dark";
 
-  // helper to store the current selected sections
+  // state to keep track of active background color
+  const [backgroundColorCourseConfig, setBackgroundColorCourseConfig] = useState("transparent")
+  const [backgroundColorMasterCourseDragging, setBackgroundColorMasterCourseDragging] = useState("transparent")
+
+  // helper to store the current selected sectionsW
   const currentSections = useMemo(
     () =>
       timetable.slots
@@ -355,7 +358,7 @@ const SideBar = () => {
 
   // Handles keypresses: "Up" decrements hoveredCourse, "Down" increments hoveredCourse (both with bounds).
   const handleKeyPress = useCallback(
-    (e) => {
+    (e: any) => {
       if (e.key === "ArrowUp") {
         if (hoveredCourse > -1) {
           setHoveredCourse((prevHoveredCourse) => prevHoveredCourse - 1);
@@ -515,6 +518,56 @@ const SideBar = () => {
     setIsChecked((prev) => !prev); // Toggle the state
   };
 
+  useEffect(() => {
+    if (isCoursePlanDragging) {
+      setBackgroundColorCourseConfig(isDarkMode ? "#3F4246" : "lightblue")
+    } else {
+      setBackgroundColorCourseConfig("transparent")
+    }
+  }, [isCoursePlanDragging, isDarkMode])
+
+  useEffect(() => {
+    if (isCoursePlanDragging) {
+      setBackgroundColorMasterCourseDragging(isDarkMode ? "#3F4246" : "lightblue")
+    } else {
+      setBackgroundColorMasterCourseDragging("transparent")
+    }
+  }, [isMasterCourseDragging, isDarkMode])
+
+  const masterSlotsColumn = (masterSlotsLen: number, coursePlanLen: number) => {
+    if (masterSlotsLen === 0 && coursePlanLen === 0) {
+      return emptyMasterSlot();
+    }
+
+    if (masterSlotsLen === 0) {
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "200px",
+          }}
+        >
+          <p
+            style={{
+              lineHeight: "1.5",
+              textAlign: "center",
+              userSelect: "none",
+            }}
+          >
+            Drag courses back here to lock in your section choice!
+          </p>
+          <button onClick={handleRemoveAllClick}>Remove All</button>
+        </div>
+      )
+    }
+
+    return masterSlots
+
+  }
+
   return (
     <div className="side-bar no-print overflow-y-auto overflow-x-hidden">
       <div className="sb-name">
@@ -560,11 +613,7 @@ const SideBar = () => {
         onDragEnd={() => handleDragEnd("masterSlotCourses")}
         onDragOver={handleDragOver}
         style={{
-          backgroundColor: isCoursePlanDragging
-            ? isDarkMode
-              ? "#3F4246"
-              : "lightblue"
-            : "transparent",
+          backgroundColor: backgroundColorCourseConfig,
           transition: "background-color 0.3s ease",
           borderBottom: "2px solid black",
           minHeight: "200px",
@@ -573,34 +622,7 @@ const SideBar = () => {
           borderTopRightRadius: "20px",
         }}
       >
-        {masterSlots.length === 0 ? (
-          coursePlan.length === 0 ? (
-            emptyMasterSlot()
-          ) : (
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                justifyContent: "center",
-                alignItems: "center",
-                height: "200px",
-              }}
-            >
-              <p
-                style={{
-                  lineHeight: "1.5",
-                  textAlign: "center",
-                  userSelect: "none",
-                }}
-              >
-                Drag courses back here to lock in your section choice!
-              </p>
-              <button onClick={handleRemoveAllClick}>Remove All</button>
-            </div>
-          )
-        ) : (
-          masterSlots
-        )}
+        {masterSlotsColumn(masterSlots.length, coursePlan.length)}
       </div>
       <div
         className="sb-course-scheduling"
@@ -658,11 +680,7 @@ const SideBar = () => {
           style={{
             minHeight: "200px",
             padding: "8px",
-            backgroundColor: isMasterCourseDragging
-              ? isDarkMode
-                ? "#3F4246"
-                : "lightblue"
-              : "transparent",
+            backgroundColor: backgroundColorMasterCourseDragging,
             transition: "background-color 0.3s ease",
             borderRadius: "20px",
             display: "flex",

--- a/static/js/redux/ui/TimetableNameInput.tsx
+++ b/static/js/redux/ui/TimetableNameInput.tsx
@@ -46,7 +46,7 @@ const TimetableNameInput = () => {
   };
 
   const handleEnterKeyPressed = useCallback(
-    (e) => {
+    (e: any) => {
       // save course when user pressed enter
       if (inputRef && e.key === "Enter") {
         setTimetableName();

--- a/static/js/redux/ui/modals/CourseModalBody.tsx
+++ b/static/js/redux/ui/modals/CourseModalBody.tsx
@@ -107,7 +107,7 @@ const CourseModalBody = (props: CourseModalBodyProps) => {
     });
 
   const handleKeyPress = useCallback(
-    (e) => {
+    (e: any) => {
       if (e.key === "ArrowRight") {
         setCurrentHoveredSection((prevSection) =>
           prevSection < sectionList.length - 1 ? prevSection + 1 : prevSection

--- a/static/js/redux/ui/optimize_schedule.tsx
+++ b/static/js/redux/ui/optimize_schedule.tsx
@@ -1,4 +1,5 @@
 // Helper functions for scheduling courses
+/* eslint no-shadow: "off" */
 import { DenormalizedCourse, Section } from "../constants/commonTypes";
 
 function timeToMinutes(time: string): number {


### PR DESCRIPTION
- disabled `camelcase` and `no-shadow` on some files, since camelcase is legacy and no-shadow is a bug
-  replaced some nesterd ternarys with state/useeffect pairs (this might be overkill... if theres any easier way to do this pls comment)
- refactor to masterslot jsx since linter was complaining abt nested ternary